### PR TITLE
Remove installing ctls and cstack

### DIFF
--- a/Dockerfile-Swift5.1
+++ b/Dockerfile-Swift5.1
@@ -1,9 +1,5 @@
 FROM swift:5.1
 
-RUN apt-get update && apt-get install -y wget apt-transport-https software-properties-common && \
-wget -q https://repo.vapor.codes/apt/keyring.gpg -O- | apt-key add - && \
-echo "deb https://repo.vapor.codes/apt $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/vapor.list && \
-apt-get update && \
-apt-get install -y libmysqlclient20 libmysqlclient-dev cstack ctls openssl libssl-dev libcurl4-openssl-dev
+RUN apt-get update && apt-get install -y libmysqlclient20 libmysqlclient-dev openssl libssl-dev libcurl4-openssl-dev
 
 CMD ["swift", "--version"]


### PR DESCRIPTION
- ctls and cstack are both packages for Vapor 2 and not needed for Vapor 3 
- also Vapor 2 doesn't run in Swift 5.1.n 
- Finally the certificate for the vapor apt-get repo that we are linking to has expired and will cause the image to fail